### PR TITLE
Add full module API listing

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,257 @@
+# PhysiCell Settings API Reference
+
+This page summarizes the public API provided by the `physicell_config` package.
+Each section lists the available classes and methods along with a short
+explanation of their purpose and parameters.
+
+## PhysiCellConfig
+Located in `physicell_config/config_builder_modular.py`.
+This class orchestrates all configuration modules and provides convenience
+helpers to generate and save complete PhysiCell XML files.
+
+### Methods
+- `__init__()` – instantiate the builder and all modules.
+- `cell_rules_csv` – property returning a `CellRulesCSV` helper with updated context.
+- `add_user_parameter(name, value, units='dimensionless', description='', parameter_type='double')` – register a custom user parameter.
+- `set_number_of_cells(count)` – convenience setter for the standard `number_of_cells` parameter.
+- `setup_basic_simulation(x_range=(-500,500), y_range=(-500,500), mesh_spacing=20.0, max_time=8640.0)` – configure domain, options and output for a common simulation.
+- `add_simple_substrate(name, diffusion_coeff=1000.0, decay_rate=0.1, initial_value=0.0)` – quick helper to create a substrate with basic parameters.
+- `add_simple_cell_type(name, secretion_substrate=None, secretion_rate=0.0, motile=False)` – add a cell type with optional secretion and motility settings.
+- `generate_xml()` – assemble the XML tree for the current configuration and return it as a string.
+- `save_xml(filename)` – generate and write the XML to disk.
+- `get_summary()` – return a dictionary summarizing domain, substrates, cell types and options.
+- `validate()` – basic sanity checks returning a list of issues found.
+- legacy helpers `set_domain`, `add_substrate`, `add_cell_type` mirror module methods.
+- `set_parallel_settings(omp_num_threads=4)` – set OpenMP thread count.
+
+## Modules
+The builder is composed of several modules located under `physicell_config/modules`.
+Each module exposes a small API focused on a single aspect of the configuration.
+
+### DomainModule
+- `set_bounds(x_min, x_max, y_min, y_max, z_min=-10.0, z_max=10.0)` – set the simulation domain limits.
+- `set_mesh(dx, dy, dz=20.0)` – mesh spacing in each dimension.
+- `set_2D(use_2D=True)` – toggle 2‑D mode.
+- `add_to_xml(parent)` – append domain settings to an XML element.
+- `get_info()` – return the currently stored domain values.
+
+### SubstrateModule
+- `set_track_internalized_substrates(enabled)` – include internalized substrate tracking flag.
+- `add_substrate(name, diffusion_coefficient=1000.0, decay_rate=0.1, initial_condition=0.0, dirichlet_enabled=False, dirichlet_value=0.0, units='dimensionless', initial_units='mmHg')` – register a new substrate and its physical parameters.
+- `set_dirichlet_boundary(substrate_name, boundary, enabled, value=0.0)` – configure boundary conditions per face.
+- `remove_substrate(name)` – delete a substrate definition.
+- `add_to_xml(parent)` – write microenvironment data to XML.
+- `get_substrates()` – return the internal dictionary of substrates.
+
+### CellTypeModule
+Handles phenotype and behavioral properties for all cell types.
+- `add_cell_type(name, parent_type='default', template='default')` – create a cell type using a predefined template.
+- Numerous setter helpers exist for cycle model, death rates, volume, motility, secretion and intracellular models (see source for full list).
+- `update_all_cell_types_for_substrates()` – ensure secretion parameters exist for all substrates.
+- `add_to_xml(parent)` – serialize all cell type definitions to XML.
+- `get_cell_types()` – return the stored cell type definitions.
+
+### CellRulesModule
+- `add_ruleset(name, folder='./config', filename='rules.csv', enabled=True)` – declare a CSV ruleset to load during simulation.
+- `add_rule(signal, behavior, cell_type, min_signal=0.0, max_signal=1.0, min_behavior=0.0, max_behavior=1.0, hill_power=1.0, half_max=0.5, applies_to_dead=False)` – add an individual rule description.
+- `load_rules_from_csv(filename)` / `save_rules_to_csv(filename)` – import or export rules in CSV format.
+- `add_to_xml(parent)` – write the cell rules structure to XML.
+- `get_rules()` / `get_rulesets()` – return defined rules and rulesets.
+
+### CellRulesCSV
+Utility class for creating valid `cell_rules.csv` files.
+- Methods to list available signals/behaviors (`get_available_signals`, `get_available_behaviors`).
+- Context helpers (`update_context_from_config`, `get_context`).
+- `add_rule(cell_type, signal, direction, behavior, base_value, half_max, hill_power, apply_to_dead)` – add a rule in CSV layout and `generate_csv(filename)` to export.
+- Includes convenience `print_*` methods to display registry information.
+
+### OptionsModule
+- `set_max_time(max_time, units='min')` – total simulation time.
+- `set_time_steps(dt_diffusion=None, dt_mechanics=None, dt_phenotype=None)` – adjust internal time steps.
+- `set_virtual_wall(enabled)` and other toggles like `set_automated_spring_adhesions`, `set_random_seed`, `set_parallel_threads`.
+- `add_to_xml(parent)` – append options to XML.
+- `get_options()` – return the stored options dictionary.
+
+### InitialConditionsModule
+- `add_cell_cluster(cell_type, x, y, z=0.0, radius=100.0, num_cells=100)` – place a sphere of cells.
+- `add_single_cell(cell_type, x, y, z=0.0)` – place a single cell.
+- `add_rectangular_region(cell_type, x_min, x_max, y_min, y_max, z_min=-5.0, z_max=5.0, density=0.8)` – fill a region with random cells.
+- `add_csv_file(filename, folder='./config', enabled=False)` – use an external CSV for initial positions.
+- `add_to_xml(parent)` – write initial conditions to XML.
+- `get_conditions()` – return the defined conditions.
+
+### SaveOptionsModule
+- `set_output_folder(folder)` – output path for simulation results.
+- `set_full_data_options(interval=None, enable=None, settings_interval=None)` – configure full data output.
+- `set_svg_options(interval=None, enable=None)` and `set_svg_plot_substrate(enabled=False, limits=False, substrate='substrate', colormap='YlOrRd', min_conc=0, max_conc=1)` for visualisation.
+- `set_svg_legend(enabled=False, cell_phase=False, cell_type=True)` – legend options.
+- `set_legacy_data(enable)` – toggle legacy format output.
+- `add_to_xml(parent)` – append save configuration.
+- `get_save_options()` – return internal save options.
+
+### PhysiBoSSModule
+- `enable_physiboss(model_file='boolean_model.bnd', initial_values=None, mutations=None, parameters=None)` – activate PhysiBoSS integration with initial settings.
+- `set_time_step(value)` and `set_scaling(value)` – adjust simulation step and scaling.
+- `add_initial_value(node, value)` / `add_mutation(cell_line, node, value)` / `add_parameter(name, value)` – modify network settings.
+- `add_to_xml(parent)` – serialize PhysiBoSS configuration when enabled.
+- `is_enabled()` – check status.
+- `get_settings()` – retrieve current options.
+
+### ConfigLoader
+Utility singleton in `physicell_config/modules/config_loader.py` used by all
+modules to pull default parameters from JSON files.
+
+- `get_cycle_model(name)` – return cycle model templates
+- `get_death_model(name)` – apoptosis or necrosis defaults
+- `get_volume_defaults()` / `get_mechanics_defaults()` / `get_motility_defaults()`
+  – phenotype defaults
+- `get_cell_type_template(template_name)` – load cell type presets
+- Built-in cell type templates: `default`, `live_cell`, `maboss_cell`
+- `get_substrate_defaults(name)` – standard substrate parameters
+
+See `docs/AdvancedFeatures.md` for more details on advanced usage.
+
+## Detailed Module Functions
+Below is a complete list of public helpers available in each module.
+
+### DomainModule
+- `set_bounds(x_min, x_max, y_min, y_max, z_min=-10.0, z_max=10.0)` – define the spatial extents of the domain.
+- `set_mesh(dx, dy, dz=20.0)` – specify grid spacing in microns.
+- `set_2D(use_2D=True)` – enable 2‑D simulations.
+- `add_to_xml(parent)` – append domain settings to an XML element.
+- `get_info()` – return current configuration as a dictionary.
+
+### SubstrateModule
+- `set_track_internalized_substrates(enabled)` – toggle tracking of internalised substrates.
+- `add_substrate(name, diffusion_coefficient=1000.0, decay_rate=0.1, initial_condition=0.0, dirichlet_enabled=False, dirichlet_value=0.0, units='dimensionless', initial_units='mmHg')` – create a substrate definition.
+- `set_dirichlet_boundary(substrate_name, boundary, enabled, value=0.0)` – set per‑face Dirichlet conditions.
+- `remove_substrate(name)` – delete an existing substrate.
+- `add_to_xml(parent)` – write microenvironment data to XML.
+- `get_substrates()` – return all defined substrates.
+
+### CellTypeModule
+- `add_cell_type(name, parent_type='default', template='default')` – create a new cell type from a template.
+- `set_cycle_model(cell_type, model)` – assign a cycle model.
+- `set_cycle_transition_rate(cell_type, from_phase, to_phase, rate)` – override specific cycle transitions.
+- `set_death_rate(cell_type, death_type, rate)` – change apoptosis or necrosis rates.
+- `set_volume_parameters(cell_type, total=None, nuclear=None, fluid_fraction=None)` – adjust volume attributes.
+- `set_motility(cell_type, speed=None, persistence_time=None, migration_bias=None, enabled=None)` – configure motility.
+- `set_chemotaxis(cell_type, substrate, enabled=True, direction=1)` – simple chemotaxis towards a substrate.
+- `set_advanced_chemotaxis(cell_type, substrate_sensitivities, enabled=True, normalize_each_gradient=False)` – multi‑substrate chemotaxis.
+- `add_secretion(cell_type, substrate, secretion_rate, secretion_target=1.0, uptake_rate=0.0, net_export_rate=0.0)` – add secretion parameters.
+- `update_all_cell_types_for_substrates()` – ensure secretion parameters exist for all substrates.
+- `add_intracellular_model(cell_type, model_type='maboss', bnd_filename='', cfg_filename='')` – attach an intracellular model.
+- `set_intracellular_settings(cell_type, intracellular_dt=None, time_stochasticity=None, scaling=None, start_time=None, inheritance_global=None)` – tweak intracellular options.
+- `add_intracellular_mutation(cell_type, intracellular_name, value)` – force a node value.
+- `add_intracellular_initial_value(cell_type, intracellular_name, value)` – set initial node value.
+- `add_intracellular_input(cell_type, physicell_name, intracellular_name, action='activation', threshold=1, smoothing=0)` – map a substrate or variable to a node.
+- `add_intracellular_output(cell_type, physicell_name, intracellular_name, action='activation', value=1000000, base_value=0, smoothing=0)` – map a node to a behavior.
+- `add_to_xml(parent)` – serialize cell definitions to XML.
+- `get_cell_types()` – return all stored cell type data.
+
+### CellRulesModule
+- `add_ruleset(name, folder='./config', filename='rules.csv', enabled=True)` – register a CSV ruleset file.
+- `add_rule(signal, behavior, cell_type, min_signal=0.0, max_signal=1.0, min_behavior=0.0, max_behavior=1.0, hill_power=1.0, half_max=0.5, applies_to_dead=False)` – store a rule description.
+- `load_rules_from_csv(filename)` – import rules from CSV.
+- `save_rules_to_csv(filename)` – export current rules to CSV.
+- `add_to_xml(parent)` – write the cell rules section.
+- `get_rules()` – list rule dictionaries.
+- `get_rulesets()` – list registered rulesets.
+- `clear_rules()` – remove all rules.
+- `clear_rulesets()` – remove all rulesets.
+
+### CellRulesCSV
+- `update_context_from_config(config)` – refresh cell types and substrates from a config instance.
+- `get_available_signals(filter_by_type=None)` – list known signals.
+- `get_available_behaviors(filter_by_type=None)` – list known behaviors.
+- `get_context()` – inspect current context.
+- `get_signal_by_name(signal_name)` – look up a signal by name.
+- `get_behavior_by_name(behavior_name)` – look up a behavior by name.
+- `add_rule(cell_type, signal, direction, behavior, base_value, half_max, hill_power, apply_to_dead)` – append a CSV rule.
+- `remove_rule(index)` – delete a rule by index.
+- `get_rules()` – list stored rules.
+- `clear_rules()` – remove all rules.
+- `generate_csv(filename)` – export a PhysiCell compatible CSV.
+- `validate_rules()` – return warnings or errors for the current rule set.
+- `print_available_signals(filter_by_type=None)` – print signals table.
+- `print_available_behaviors(filter_by_type=None)` – print behaviors table.
+- `print_context()` – display current context.
+- `print_rules()` – display the rule list.
+- `add_to_xml(parent)` – no-op placeholder for compatibility.
+
+### OptionsModule
+- `set_max_time(max_time, units='min')` – simulation duration.
+- `set_time_steps(dt_diffusion=None, dt_mechanics=None, dt_phenotype=None)` – override solver time steps.
+- `set_virtual_wall(enabled)` – toggle boundary walls.
+- `set_automated_spring_adhesions(disabled)` – disable automated adhesions.
+- `set_random_seed(seed)` – RNG seed.
+- `set_legacy_random_points(enabled)` – use legacy division points.
+- `set_parallel_threads(num_threads)` – OpenMP thread count.
+- `add_to_xml(parent)` – append options to XML.
+- `get_options()` – retrieve the options dictionary.
+
+### InitialConditionsModule
+- `add_cell_cluster(cell_type, x, y, z=0.0, radius=100.0, num_cells=100)` – place a spherical cluster.
+- `add_single_cell(cell_type, x, y, z=0.0)` – place one cell.
+- `add_rectangular_region(cell_type, x_min, x_max, y_min, y_max, z_min=-5.0, z_max=5.0, density=0.8)` – populate a region.
+- `add_csv_file(filename, folder='./config', enabled=False)` – import positions from CSV.
+- `add_to_xml(parent)` – write initial conditions to XML.
+- `get_conditions()` – return configured conditions.
+- `clear_conditions()` – remove all conditions.
+
+### SaveOptionsModule
+- `set_output_folder(folder)` – output directory.
+- `set_full_data_options(interval=None, enable=None, settings_interval=None)` – full data dump settings.
+- `set_svg_options(interval=None, enable=None)` – global SVG settings.
+- `set_svg_plot_substrate(enabled=False, limits=False, substrate='substrate', colormap='YlOrRd', min_conc=0, max_conc=1)` – substrate plot control.
+- `set_svg_legend(enabled=False, cell_phase=False, cell_type=True)` – legend visibility.
+- `set_legacy_data(enable)` – legacy output files.
+- `add_to_xml(parent)` – append save configuration.
+- `get_save_options()` – return save options.
+
+### PhysiBoSSModule
+- `enable_physiboss(model_file='boolean_model.bnd', initial_values=None, mutations=None, parameters=None)` – activate the Boolean network.
+- `set_time_step(value)` – network step size in minutes.
+- `set_scaling(value)` – scale network speed.
+- `add_initial_value(node, value)` – set a node's initial state.
+- `add_mutation(cell_line, node, value)` – force a mutation for a cell line.
+- `add_parameter(name, value)` – additional simulator parameter.
+- `add_to_xml(parent)` – export settings if enabled.
+- `is_enabled()` – check whether PhysiBoSS is active.
+- `get_settings()` – retrieve current PhysiBoSS options.
+
+### ConfigLoader
+- `get_cycle_model(name)`
+- `get_death_model(name)`
+- `get_volume_defaults()`
+- `get_mechanics_defaults()`
+- `get_motility_defaults()`
+- `get_secretion_defaults()`
+- `get_cell_interactions_defaults()`
+- `get_cell_transformations_defaults()`
+- `get_cell_integrity_defaults()`
+- `get_custom_data_defaults(data_type='sample')`
+- `get_initial_parameter_distributions_defaults()`
+- `get_intracellular_defaults(intracellular_type='maboss')`
+- `get_cell_type_template(template_name)`
+- `get_substrate_defaults(name='substrate')`
+- `get_default_phenotype(template='default')`
+## Package Weaknesses and Possible Improvements
+While the package offers a comprehensive API, several aspects could be enhanced:
+
+1. **Limited automated testing** – `test_modular.py` acts mostly as a demo.
+   Adding unit tests for each module and integrating continuous integration would
+   improve reliability.
+2. **Sparse documentation for advanced features** – some complex methods
+   lack detailed examples. Extended tutorials and docstrings would ease adoption.
+3. **Validation gaps** – configuration validation currently checks only a few
+   conditions. More thorough checks (e.g. verifying cross‑module consistency) can
+   prevent runtime errors.
+4. **No explicit versioned schema** – the XML generation assumes a single
+   schema. Providing version compatibility layers or schema definitions would help
+   long‑term maintenance.
+5. **Dependency on large JSON defaults** – modifying default parameters requires
+   editing JSON files manually. A helper API for managing these defaults could
+   simplify customization.
+
+Addressing these items would make the project more robust and easier to extend.

--- a/docs/AdvancedFeatures.md
+++ b/docs/AdvancedFeatures.md
@@ -1,0 +1,192 @@
+# Advanced Features Guide
+
+This document expands upon `docs/API.md` and describes the advanced capabilities
+of the `physicell_config` package. The goal is to provide enough detail for
+another agent or service to automate complex PhysiCell configuration tasks,
+including building MCP (Model Context Protocol) servers around the API.
+
+## ConfigLoader
+`physicell_config/modules/config_loader.py`
+
+`ConfigLoader` is a singleton responsible for loading JSON defaults used by the
+modules. It exposes methods such as:
+
+- `get_cycle_model(name)` – retrieve default cell cycle model data
+- `get_death_model(name)` – retrieve apoptosis/necrosis defaults
+- `get_volume_defaults()` / `get_mechanics_defaults()` / `get_motility_defaults()`
+  – volume and mechanics templates used when creating cell types
+- `get_cell_type_template(template_name)` – access full cell type presets
+- `get_substrate_defaults(name)` – default substrate physical parameters
+
+These defaults are defined in `config/default_parameters.json` and
+`config/signals_behaviors.json` and are used whenever a module needs a
+predefined structure. Services can load the same JSON if custom defaults are
+required.
+
+### JSON Templates
+The package ships two main JSON files under `physicell_config/config` that
+provide all default settings used by the modules:
+
+- **`default_parameters.json`** – contains reusable snippets for
+  `cell_cycle_models`, `death_models`, phenotype defaults (volume, mechanics,
+  motility, secretion, interactions, transformations and integrity),
+  `intracellular_defaults` and a list of `cell_type_templates`. Each cell type
+  template groups these snippets so that calling
+  `CellTypeModule.add_cell_type(name, template="live_cell")` will create a new
+  cell type pre‑populated with the values stored under the corresponding entry in
+  the JSON file.
+- The packaged templates are `default`, `live_cell` and `maboss_cell`.
+
+#### Cell Type Template Details
+
+Each entry in `cell_type_templates` bundles default phenotype components,
+cycle models and optional intracellular settings that are used by
+`CellTypeModule.add_cell_type`.  Below is a summary of the shipped templates:
+
+- **`default`** – uses the `flow_cytometry_separated` cycle model with the
+  standard phenotype defaults from this JSON.  Only the custom data field
+  `sample` is included, leaving room for additional user variables.  This is the
+  most generic starting point for user-defined cell types.
+- **`live_cell`** – specifies the minimal `live` cycle model so cells never
+  divide by default.  The phenotype defaults are identical to the `default`
+  template but the custom data section contains a single `somedata` entry.  It
+  is intended for simple simulations focusing on secretion or motility without
+  cell proliferation.
+- **`maboss_cell`** – extends `live_cell` by also enabling an intracellular
+  MaBoSS network (`intracellular` set to `maboss`).  When a cell type is created
+  from this template, the Boolean network described under
+  `intracellular_defaults.maboss` is attached automatically, ready for further
+  mutations or parameter tweaks.
+- **`signals_behaviors.json`** – lists all known rule signals and behaviors along
+  with IDs and descriptions. `CellRulesCSV` reads this registry so that new
+  rules always reference valid names and required context variables.
+
+Inspecting or editing these JSON files allows you to customise defaults or
+extend the available rule definitions without modifying the Python code.
+
+## Advanced Cell Type Operations
+`physicell_config/modules/cell_types.py`
+
+Beyond the basic `add_cell_type`, this module provides extensive control over
+phenotype and intracellular models:
+
+- `set_cycle_model(cell_type, model)` – switch to any of the built in cycle
+  models loaded from `ConfigLoader`
+- `set_cycle_transition_rate(cell_type, from_phase, to_phase, rate)` – modify
+  specific phase transitions
+- `set_death_rate(cell_type, death_type, rate)` – adjust apoptosis or necrosis
+  rates
+- `set_volume_parameters(cell_type, total=None, nuclear=None, fluid_fraction=None)`
+  – tweak volume properties
+- `set_motility(cell_type, speed=None, persistence_time=None, migration_bias=None,
+  enabled=None)`
+- `set_chemotaxis(cell_type, substrate, enabled=True, direction=1)` – simple
+  chemotaxis toward a substrate
+- `set_advanced_chemotaxis(cell_type, substrate_sensitivities, enabled=True,
+  normalize_each_gradient=False)` – define multiple substrate sensitivities
+- `add_intracellular_model(cell_type, model_type='maboss', bnd_filename='',
+  cfg_filename='')` – attach an intracellular network
+- `set_intracellular_settings(cell_type, intracellular_dt=None, time_stochasticity=None,
+  scaling=None, start_time=None, inheritance_global=None)`
+- `add_intracellular_mutation(cell_type, intracellular_name, value)`
+- `add_intracellular_initial_value(cell_type, intracellular_name, value)`
+- `add_intracellular_input(cell_type, physicell_name, intracellular_name, action='activation',
+  threshold=1, smoothing=0)`
+- `add_intracellular_output(cell_type, physicell_name, intracellular_name,
+  action='activation', value=1000000, base_value=0, smoothing=0)`
+
+These methods allow programmatic construction of complex cell behaviours and
+are typically required when assembling model-aware MCP servers.
+
+## Cell Rules and CSV Generation
+`physicell_config/modules/cell_rules.py`
+
+- `add_ruleset(name, folder='./config', filename='rules.csv', enabled=True)` –
+  register external rule files
+- `add_rule(...)` – create rules programmatically
+- `load_rules_from_csv(filename)` / `save_rules_to_csv(filename)` – interchange
+  rules with CSV
+- `clear_rules()` / `clear_rulesets()` – reset configuration
+
+`cell_rules_csv.py` wraps these rules in a CSV oriented helper that is aware of
+available signals and behaviors. Key calls include:
+
+- `get_available_signals(filter_by_type=None)`
+- `get_available_behaviors(filter_by_type=None)`
+- `get_context()` – inspect current cell types, substrates and custom variables
+- `add_rule(cell_type, signal, direction, behavior, base_value, half_max,
+  hill_power, apply_to_dead)`
+- `generate_csv(filename)` – produce a CSV ready for PhysiCell
+
+The context awareness ensures that generated rules only reference entities
+present in the configuration.
+
+## PhysiBoSS Integration
+`physicell_config/modules/physiboss.py`
+
+`PhysiBoSSModule` enables intracellular boolean networks. Typical usage:
+
+```python
+config.physiboss.enable_physiboss('model.bnd', initial_values={'p53': True})
+config.physiboss.set_time_step(6.0)
+config.physiboss.add_mutation('cancer_cell', 'EGFR', False)
+```
+
+All settings are exported through `add_to_xml()` if the module is enabled.
+
+## Initial Conditions
+`physicell_config/modules/initial_conditions.py`
+
+Methods allow direct placement of cells or reading from CSV:
+
+- `add_cell_cluster(cell_type, x, y, z=0.0, radius=100.0, num_cells=100)`
+- `add_single_cell(cell_type, x, y, z=0.0)`
+- `add_rectangular_region(cell_type, x_min, x_max, y_min, y_max, z_min=-5.0,
+  z_max=5.0, density=0.8)`
+- `add_csv_file(filename, folder='./config', enabled=False)`
+
+For MCP automation this module is typically populated from user provided
+geometry descriptions.
+
+## Save Options and Runtime Parameters
+`physicell_config/modules/save_options.py` and `options.py`
+
+These modules configure output frequency and core simulation options. Examples:
+
+```python
+config.save_options.set_svg_plot_substrate(True, substrate='oxygen', colormap='viridis')
+config.options.set_parallel_threads(8)
+```
+
+## Building MCP Servers
+To build an HTTP service that generates simulation XML from client requests you
+can wrap `PhysiCellConfig` in a web framework. Below is a minimal `FastAPI`
+skeleton illustrating the concept:
+
+```python
+from fastapi import FastAPI
+from pydantic import BaseModel
+from physicell_config import PhysiCellConfig
+
+app = FastAPI()
+
+class SimulationRequest(BaseModel):
+    substrates: dict
+    cell_types: list
+
+@app.post('/generate')
+def generate(req: SimulationRequest):
+    config = PhysiCellConfig()
+    for name, params in req.substrates.items():
+        config.substrates.add_substrate(name, **params)
+    for ct in req.cell_types:
+        config.cell_types.add_cell_type(ct['name'])
+    xml_str = config.generate_xml()
+    return {'xml': xml_str}
+```
+
+
+Further wrappers can drive such a server using natural language or structured
+commands. Refer to the API reference for building blocks.
+
+

--- a/physicell_config/modules/__init__.py
+++ b/physicell_config/modules/__init__.py
@@ -1,7 +1,8 @@
-"""
-PhysiCell Configuration Builder Modules
+"""Collection of configuration modules used by :class:`PhysiCellConfig`.
 
-This package contains modular components for building PhysiCell XML configurations.
+Each submodule handles a single aspect of the configuration such as domain
+geometry, substrates or cell rules.  They are imported lazily to avoid circular
+dependencies when constructing the main configuration object.
 """
 
 # Import modules only when needed to avoid circular imports

--- a/physicell_config/modules/base.py
+++ b/physicell_config/modules/base.py
@@ -1,5 +1,10 @@
-"""
-Base module for PhysiCell configuration components.
+"""Base utilities shared by all configuration modules.
+
+This module defines :class:`BaseModule`, a lightweight helper providing
+XML element creation and numeric validation routines used by the other
+modules in :mod:`physicell_config`.  Modules store a reference to the
+parent :class:`~physicell_config.config_builder_modular.PhysiCellConfig`
+instance so they can interact with each other when generating XML.
 """
 
 from typing import Dict, Any, List, Optional
@@ -7,33 +12,75 @@ import xml.etree.ElementTree as ET
 
 
 class BaseModule:
-    """Base class for configuration modules."""
+    """Base class for all configuration modules.
+
+    Parameters
+    ----------
+    config:
+        Parent :class:`PhysiCellConfig` instance used for cross-module
+        communication.
+    """
     
     def __init__(self, config: 'PhysiCellConfig'):
-        """Initialize module with reference to parent config."""
+        """Store a reference to the parent configuration object."""
         self._config = config
     
-    def _create_element(self, parent: ET.Element, tag: str, 
-                       text: Optional[str] = None, 
+    def _create_element(self, parent: ET.Element, tag: str,
+                       text: Optional[str] = None,
                        attrib: Optional[Dict[str, str]] = None) -> ET.Element:
-        """Helper to create XML elements."""
+        """Create an XML element and append it to *parent*.
+
+        Parameters
+        ----------
+        parent:
+            The element that will contain the new node.
+        tag:
+            Tag name of the element to create.
+        text:
+            Optional text value for the element.
+        attrib:
+            Dictionary of attributes for the new element.
+
+        Returns
+        -------
+        xml.etree.ElementTree.Element
+            The newly created element.
+        """
         element = ET.SubElement(parent, tag, attrib or {})
         if text is not None:
             element.text = str(text)
         return element
     
     def _validate_positive_number(self, value: float, name: str) -> None:
-        """Validate that a value is a positive number."""
+        """Validate that *value* is a positive number.
+
+        Raises
+        ------
+        ValueError
+            If *value* is not greater than zero.
+        """
         if not isinstance(value, (int, float)) or value <= 0:
             raise ValueError(f"{name} must be a positive number, got {value}")
     
     def _validate_non_negative_number(self, value: float, name: str) -> None:
-        """Validate that a value is a non-negative number."""
+        """Validate that *value* is zero or positive.
+
+        Raises
+        ------
+        ValueError
+            If *value* is negative.
+        """
         if not isinstance(value, (int, float)) or value < 0:
             raise ValueError(f"{name} must be a non-negative number, got {value}")
 
     def _validate_number_in_range(self, value: float, min_val: float, max_val: float, name: str) -> None:
-        """Validate that a value is within a specified range."""
+        """Validate that *value* is within ``min_val`` and ``max_val``.
+
+        Raises
+        ------
+        ValueError
+            If *value* is outside the provided range or not numeric.
+        """
         if not isinstance(value, (int, float)):
             raise ValueError(f"{name} must be a number, got {type(value).__name__}")
         if value < min_val or value > max_val:

--- a/physicell_config/modules/cell_rules.py
+++ b/physicell_config/modules/cell_rules.py
@@ -16,9 +16,21 @@ class CellRulesModule(BaseModule):
         self.rulesets = {}
         self.rules = []
     
-    def add_ruleset(self, name: str, folder: str = "./config", 
+    def add_ruleset(self, name: str, folder: str = "./config",
                    filename: str = "rules.csv", enabled: bool = True) -> None:
-        """Add a ruleset to the configuration."""
+        """Register a CSV ruleset.
+
+        Parameters
+        ----------
+        name:
+            Identifier for the ruleset.
+        folder:
+            Folder where the CSV file resides.
+        filename:
+            Name of the CSV file containing the rules.
+        enabled:
+            Whether the ruleset should be loaded by PhysiCell.
+        """
         self.rulesets[name] = {
             'folder': folder,
             'filename': filename,
@@ -30,7 +42,21 @@ class CellRulesModule(BaseModule):
                 min_behavior: float = 0.0, max_behavior: float = 1.0,
                 hill_power: float = 1.0, half_max: float = 0.5,
                 applies_to_dead: bool = False) -> None:
-        """Add a cell rule."""
+        """Add a single rule to ``cell_rules``.
+
+        Parameters
+        ----------
+        signal, behavior, cell_type:
+            Entities involved in the rule definition.
+        min_signal, max_signal:
+            Signal range that triggers the behaviour.
+        min_behavior, max_behavior:
+            Bounds for the resulting behaviour value.
+        hill_power, half_max:
+            Parameters of the Hill function controlling the response.
+        applies_to_dead:
+            Set to ``True`` if the rule should be evaluated for dead cells.
+        """
         rule = {
             'signal': signal,
             'behavior': behavior,
@@ -46,7 +72,13 @@ class CellRulesModule(BaseModule):
         self.rules.append(rule)
     
     def load_rules_from_csv(self, filename: str) -> None:
-        """Load rules from a CSV file."""
+        """Read rule definitions from an external CSV file.
+
+        Parameters
+        ----------
+        filename:
+            Path to the CSV file produced by tools such as :class:`CellRulesCSV`.
+        """
         try:
             with open(filename, 'r', newline='') as csvfile:
                 reader = csv.DictReader(csvfile)
@@ -71,7 +103,13 @@ class CellRulesModule(BaseModule):
             raise ValueError(f"Error loading rules from '{filename}': {str(e)}")
     
     def save_rules_to_csv(self, filename: str) -> None:
-        """Save rules to a CSV file."""
+        """Write all currently stored rules to a CSV file.
+
+        Parameters
+        ----------
+        filename:
+            Destination path for the generated CSV.
+        """
         if not self.rules:
             raise ValueError("No rules to save")
         
@@ -88,7 +126,13 @@ class CellRulesModule(BaseModule):
             raise ValueError(f"Error saving rules to '{filename}': {str(e)}")
     
     def add_to_xml(self, parent: ET.Element) -> None:
-        """Add cell rules configuration to XML."""
+        """Serialize cell rules into the PhysiCell XML tree.
+
+        Parameters
+        ----------
+        parent:
+            Parent XML element representing ``microenvironment_setup``.
+        """
         # Always add cell_rules section, even if empty or disabled
         cell_rules_elem = self._create_element(parent, "cell_rules")
         
@@ -123,17 +167,17 @@ class CellRulesModule(BaseModule):
         self._create_element(cell_rules_elem, "settings")
     
     def get_rules(self) -> List[Dict[str, Any]]:
-        """Get all rules."""
+        """Return a copy of all stored rule dictionaries."""
         return self.rules.copy()
     
     def get_rulesets(self) -> Dict[str, Dict[str, Any]]:
-        """Get all rulesets."""
+        """Return a copy of the registered rulesets."""
         return self.rulesets.copy()
     
     def clear_rules(self) -> None:
-        """Clear all rules."""
+        """Remove every rule from the internal list."""
         self.rules.clear()
     
     def clear_rulesets(self) -> None:
-        """Clear all rulesets."""
+        """Remove all registered rulesets."""
         self.rulesets.clear()

--- a/physicell_config/modules/cell_rules_csv.py
+++ b/physicell_config/modules/cell_rules_csv.py
@@ -15,10 +15,17 @@ from .base import BaseModule
 
 
 class CellRulesCSV(BaseModule):
-    """
-    Manages cell rules and generates PhysiCell-compatible CSV files.
-    
-    The CSV format follows: cell_type,signal,direction,behavior,base_value,half_max,hill_power,apply_to_dead
+    """Utility for creating ``cell_rules.csv`` files.
+
+    This helper keeps a registry of valid signals and behaviors loaded from
+    :file:`signals_behaviors.json` located in ``physicell_config/config`` and
+    tracks the available cell types and substrates from the configuration.
+    Rules can be added programmatically and exported in the exact CSV layout
+    required by PhysiCell.
+
+    The CSV format produced is::
+
+        cell_type,signal,direction,behavior,base_value,half_max,hill_power,apply_to_dead
     """
     
     def __init__(self, config_instance=None):

--- a/physicell_config/modules/cell_types.py
+++ b/physicell_config/modules/cell_types.py
@@ -1,5 +1,10 @@
-"""
-Cell types configuration module for PhysiCell.
+"""Cell type configuration helpers for PhysiCell.
+
+This module exposes :class:`CellTypeModule` which stores phenotype and custom
+data for each defined cell type.  Helper methods are provided for setting cycle
+models, death rates, motility parameters, secretion, and intracellular models.
+The class ultimately serializes all definitions to XML under the
+``cell_definitions`` section.
 """
 
 from typing import Dict, Any, List, Optional, Tuple
@@ -9,14 +14,27 @@ from .config_loader import config_loader
 
 
 class CellTypeModule(BaseModule):
-    """Handles cell type configuration for PhysiCell simulations."""
+    """Manage multiple cell types and their phenotypes."""
     
     def __init__(self, config):
         super().__init__(config)
         self.cell_types = {}
     
     def add_cell_type(self, name: str, parent_type: str = "default", template: str = "default") -> None:
-        """Add a cell type to the configuration."""
+        """Create a new cell type entry.
+
+        Parameters
+        ----------
+        name:
+            Unique identifier for the cell type.
+        parent_type:
+            Name of the parent type to inherit from, usually ``"default"``.
+        template:
+            Template key from ``cell_type_templates`` defined in
+            :file:`default_parameters.json`. Each entry bundles the cycle model,
+            phenotype defaults and optional intracellular settings used to
+            populate the new cell type.
+        """
         self.cell_types[name] = {
             'name': name,
             'parent_type': parent_type,
@@ -95,7 +113,15 @@ class CellTypeModule(BaseModule):
         return config_loader.get_default_phenotype("default")
     
     def set_cycle_model(self, cell_type: str, model: str) -> None:
-        """Set the cell cycle model for a cell type."""
+        """Assign a predefined cell cycle model to ``cell_type``.
+
+        Parameters
+        ----------
+        cell_type:
+            Name of the cell type to modify.
+        model:
+            One of the models available via :func:`ConfigLoader.get_cycle_model`.
+        """
         if cell_type not in self.cell_types:
             raise ValueError(f"Cell type '{cell_type}' not found")
         

--- a/physicell_config/modules/config_loader.py
+++ b/physicell_config/modules/config_loader.py
@@ -1,5 +1,8 @@
-"""
-Configuration loader for PhysiCell default parameters.
+"""Utility for loading default parameters from JSON files.
+
+``ConfigLoader`` centralises access to the JSON templates shipped with the
+package.  Each method returns a dictionary suitable for direct insertion into
+the configuration modules so that defaults can be reused or extended.
 """
 
 import json
@@ -9,7 +12,11 @@ from pathlib import Path
 
 
 class ConfigLoader:
-    """Loads and manages default PhysiCell configuration parameters."""
+    """Loader for default PhysiCell configuration snippets.
+
+    The loader reads ``default_parameters.json`` at first use and provides
+    convenience methods to retrieve common phenotype or substrate templates.
+    """
     
     def __init__(self):
         self._config = None

--- a/physicell_config/modules/domain.py
+++ b/physicell_config/modules/domain.py
@@ -1,6 +1,4 @@
-"""
-Domain configuration module for PhysiCell.
-"""
+"""Domain size and mesh configuration."""
 
 from typing import Dict, Any, List, Optional, Tuple
 import xml.etree.ElementTree as ET
@@ -8,7 +6,7 @@ from .base import BaseModule
 
 
 class DomainModule(BaseModule):
-    """Handles domain configuration for PhysiCell simulations."""
+    """Manage simulation bounds and mesh spacing."""
     
     def __init__(self, config):
         super().__init__(config)
@@ -27,7 +25,13 @@ class DomainModule(BaseModule):
     
     def set_bounds(self, x_min: float, x_max: float, y_min: float, y_max: float,
                    z_min: float = -10.0, z_max: float = 10.0) -> None:
-        """Set the domain bounds."""
+        """Configure the physical extents of the simulation space.
+
+        Parameters
+        ----------
+        x_min, x_max, y_min, y_max, z_min, z_max:
+            Coordinates describing the box boundaries in microns.
+        """
         self.data.update({
             'x_min': x_min,
             'x_max': x_max,
@@ -38,7 +42,13 @@ class DomainModule(BaseModule):
         })
     
     def set_mesh(self, dx: float, dy: float, dz: float = 20.0) -> None:
-        """Set the mesh spacing."""
+        """Set the Cartesian mesh spacing in each dimension.
+
+        Parameters
+        ----------
+        dx, dy, dz:
+            Grid spacing in microns.
+        """
         self._validate_positive_number(dx, "dx")
         self._validate_positive_number(dy, "dy")
         self._validate_positive_number(dz, "dz")
@@ -50,11 +60,23 @@ class DomainModule(BaseModule):
         })
     
     def set_2D(self, use_2D: bool = True) -> None:
-        """Set whether to use 2D simulation."""
+        """Toggle 2‑D simulation mode.
+
+        Parameters
+        ----------
+        use_2D:
+            ``True`` for planar simulations, ``False`` for 3‑D.
+        """
         self.data['use_2D'] = use_2D
     
     def add_to_xml(self, parent: ET.Element) -> None:
-        """Add domain configuration to XML."""
+        """Append domain settings to the output XML tree.
+
+        Parameters
+        ----------
+        parent:
+            The root ``PhysiCell_settings`` XML element.
+        """
         domain_elem = self._create_element(parent, "domain")
         
         # Add bounds (no units for basic elements)
@@ -74,5 +96,5 @@ class DomainModule(BaseModule):
         self._create_element(domain_elem, "use_2D", str(self.data['use_2D']).lower())
     
     def get_info(self) -> Dict[str, Any]:
-        """Get domain information."""
+        """Return a copy of the current domain configuration."""
         return self.data.copy()

--- a/physicell_config/modules/initial_conditions.py
+++ b/physicell_config/modules/initial_conditions.py
@@ -1,6 +1,4 @@
-"""
-Initial conditions configuration module for PhysiCell.
-"""
+"""Placement of cells at the start of the simulation."""
 
 from typing import Dict, Any, List, Optional, Tuple
 import xml.etree.ElementTree as ET
@@ -8,7 +6,7 @@ from .base import BaseModule
 
 
 class InitialConditionsModule(BaseModule):
-    """Handles initial conditions configuration for PhysiCell simulations."""
+    """Define initial cell locations and placement files."""
     
     def __init__(self, config):
         super().__init__(config)
@@ -16,7 +14,19 @@ class InitialConditionsModule(BaseModule):
     
     def add_cell_cluster(self, cell_type: str, x: float, y: float, z: float = 0.0,
                         radius: float = 100.0, num_cells: int = 100) -> None:
-        """Add a cluster of cells at specified location."""
+        """Place a spherical cluster of cells.
+
+        Parameters
+        ----------
+        cell_type:
+            Cell type name.
+        x, y, z:
+            Coordinates of the cluster centre.
+        radius:
+            Sphere radius in microns.
+        num_cells:
+            Number of cells to generate.
+        """
         condition = {
             'type': 'cluster',
             'cell_type': cell_type,
@@ -29,7 +39,15 @@ class InitialConditionsModule(BaseModule):
         self.initial_conditions.append(condition)
     
     def add_single_cell(self, cell_type: str, x: float, y: float, z: float = 0.0) -> None:
-        """Add a single cell at specified location."""
+        """Place one cell in the simulation domain.
+
+        Parameters
+        ----------
+        cell_type:
+            Cell type name.
+        x, y, z:
+            Coordinates of the cell.
+        """
         condition = {
             'type': 'single',
             'cell_type': cell_type,
@@ -42,7 +60,17 @@ class InitialConditionsModule(BaseModule):
     def add_rectangular_region(self, cell_type: str, x_min: float, x_max: float,
                               y_min: float, y_max: float, z_min: float = -5.0,
                               z_max: float = 5.0, density: float = 0.8) -> None:
-        """Add cells in a rectangular region."""
+        """Fill a rectangular region with randomly placed cells.
+
+        Parameters
+        ----------
+        cell_type:
+            Name of the cell type.
+        x_min, x_max, y_min, y_max, z_min, z_max:
+            Bounds of the region.
+        density:
+            Fraction of the region volume filled with cells (0-1).
+        """
         condition = {
             'type': 'rectangle',
             'cell_type': cell_type,
@@ -57,7 +85,17 @@ class InitialConditionsModule(BaseModule):
         self.initial_conditions.append(condition)
     
     def add_csv_file(self, filename: str, folder: str = "./config", enabled: bool = False) -> None:
-        """Add CSV file for cell positions."""
+        """Specify an external CSV file for cell positions.
+
+        Parameters
+        ----------
+        filename:
+            CSV file name.
+        folder:
+            Folder containing the file.
+        enabled:
+            Whether PhysiCell should load the file.
+        """
         self.initial_conditions = {
             'type': 'csv',
             'filename': filename,
@@ -126,9 +164,9 @@ class InitialConditionsModule(BaseModule):
         self._create_element(file_elem, "filename", condition['filename'])
     
     def get_conditions(self) -> List[Dict[str, Any]]:
-        """Get all initial conditions."""
+        """Return a copy of all currently defined conditions."""
         return self.initial_conditions.copy()
     
     def clear_conditions(self) -> None:
-        """Clear all initial conditions."""
+        """Remove all stored initial conditions."""
         self.initial_conditions.clear()

--- a/physicell_config/modules/options.py
+++ b/physicell_config/modules/options.py
@@ -1,6 +1,4 @@
-"""
-Options configuration module for PhysiCell.
-"""
+"""Simulation and numeric options."""
 
 from typing import Dict, Any, List, Optional
 import xml.etree.ElementTree as ET
@@ -8,7 +6,7 @@ from .base import BaseModule
 
 
 class OptionsModule(BaseModule):
-    """Handles options configuration for PhysiCell simulations."""
+    """Configure general simulation options such as time steps."""
     
     def __init__(self, config):
         super().__init__(config)
@@ -27,14 +25,28 @@ class OptionsModule(BaseModule):
         }
     
     def set_max_time(self, max_time: float, units: str = 'min') -> None:
-        """Set maximum simulation time."""
+        """Define the total simulation duration.
+
+        Parameters
+        ----------
+        max_time:
+            Final time value.
+        units:
+            Time units (``'min'`` or ``'hour'``).
+        """
         self._validate_positive_number(max_time, "max_time")
         self.options['max_time'] = max_time
         self.options['time_units'] = units
     
     def set_time_steps(self, dt_diffusion: float = None, dt_mechanics: float = None,
                       dt_phenotype: float = None) -> None:
-        """Set simulation time steps."""
+        """Specify numerical integration time steps.
+
+        Parameters
+        ----------
+        dt_diffusion, dt_mechanics, dt_phenotype:
+            Optional overrides for the default time steps.
+        """
         if dt_diffusion is not None:
             self._validate_positive_number(dt_diffusion, "dt_diffusion")
             self.options['dt_diffusion'] = dt_diffusion
@@ -48,23 +60,29 @@ class OptionsModule(BaseModule):
             self.options['dt_phenotype'] = dt_phenotype
     
     def set_virtual_wall(self, enabled: bool) -> None:
-        """Set virtual wall at domain edge."""
+        """Enable or disable the domain boundary wall.
+
+        Parameters
+        ----------
+        enabled:
+            ``True`` to prevent cells leaving the domain.
+        """
         self.options['virtual_wall_at_domain_edge'] = enabled
     
     def set_automated_spring_adhesions(self, disabled: bool) -> None:
-        """Set automated spring adhesions."""
+        """Toggle automated spring adhesion feature."""
         self.options['disable_automated_spring_adhesions'] = disabled
     
     def set_random_seed(self, seed: int) -> None:
-        """Set random seed."""
+        """Specify the random number generator seed."""
         self.options['random_seed'] = seed
     
     def set_legacy_random_points(self, enabled: bool) -> None:
-        """Set legacy random points on sphere in divide."""
+        """Use legacy division positioning algorithm."""
         self.options['legacy_random_points_on_sphere_in_divide'] = enabled
     
     def set_parallel_threads(self, num_threads: int) -> None:
-        """Set number of OpenMP threads."""
+        """Set number of OpenMP threads used by the simulation."""
         if num_threads < 1:
             raise ValueError("Number of threads must be at least 1")
         self.options['omp_num_threads'] = num_threads

--- a/physicell_config/modules/physiboss.py
+++ b/physicell_config/modules/physiboss.py
@@ -1,6 +1,4 @@
-"""
-PhysiBoSS configuration module for PhysiCell.
-"""
+"""Intracellular boolean network support via PhysiBoSS."""
 
 from typing import Dict, Any, List, Optional
 import xml.etree.ElementTree as ET
@@ -8,7 +6,7 @@ from .base import BaseModule
 
 
 class PhysiBoSSModule(BaseModule):
-    """Handles PhysiBoSS configuration for PhysiCell simulations."""
+    """Configure PhysiBoSS integration and export settings."""
     
     def __init__(self, config):
         super().__init__(config)
@@ -19,7 +17,19 @@ class PhysiBoSSModule(BaseModule):
                         initial_values: Optional[Dict[str, bool]] = None,
                         mutations: Optional[Dict[str, Dict[str, bool]]] = None,
                         parameters: Optional[Dict[str, float]] = None) -> None:
-        """Enable PhysiBoSS with configuration."""
+        """Enable PhysiBoSS with the given boolean network model.
+
+        Parameters
+        ----------
+        model_file:
+            Path to the `.bnd` file defining the network.
+        initial_values:
+            Mapping of node names to their initial boolean state.
+        mutations:
+            Dict of cell-line specific mutations.
+        parameters:
+            Additional simulation parameters.
+        """
         self.enabled = True
         self.physiboss_settings = {
             'model_file': model_file,
@@ -32,27 +42,27 @@ class PhysiBoSSModule(BaseModule):
         }
     
     def set_time_step(self, time_step: float) -> None:
-        """Set PhysiBoSS time step."""
+        """Set the internal Boolean network time step in minutes."""
         if not self.enabled:
             raise ValueError("PhysiBoSS must be enabled first")
         self._validate_positive_number(time_step, "time_step")
         self.physiboss_settings['time_step'] = time_step
     
     def set_scaling(self, scaling: float) -> None:
-        """Set PhysiBoSS scaling factor."""
+        """Scale the boolean network execution speed."""
         if not self.enabled:
             raise ValueError("PhysiBoSS must be enabled first")
         self._validate_positive_number(scaling, "scaling")
         self.physiboss_settings['scaling'] = scaling
     
     def add_initial_value(self, node: str, value: bool) -> None:
-        """Add initial value for a boolean node."""
+        """Assign an initial boolean value to ``node``."""
         if not self.enabled:
             raise ValueError("PhysiBoSS must be enabled first")
         self.physiboss_settings['initial_values'][node] = value
     
     def add_mutation(self, cell_line: str, node: str, value: bool) -> None:
-        """Add mutation for a cell line."""
+        """Force ``node`` to ``value`` for a specific cell line."""
         if not self.enabled:
             raise ValueError("PhysiBoSS must be enabled first")
         if cell_line not in self.physiboss_settings['mutations']:
@@ -60,7 +70,7 @@ class PhysiBoSSModule(BaseModule):
         self.physiboss_settings['mutations'][cell_line][node] = value
     
     def add_parameter(self, name: str, value: float) -> None:
-        """Add parameter."""
+        """Set an additional PhysiBoSS parameter."""
         if not self.enabled:
             raise ValueError("PhysiBoSS must be enabled first")
         self.physiboss_settings['parameters'][name] = value

--- a/physicell_config/modules/save_options.py
+++ b/physicell_config/modules/save_options.py
@@ -1,6 +1,4 @@
-"""
-Save options configuration module for PhysiCell.
-"""
+"""Output file and visualization settings."""
 
 from typing import Dict, Any, List, Optional
 import xml.etree.ElementTree as ET
@@ -8,7 +6,7 @@ from .base import BaseModule
 
 
 class SaveOptionsModule(BaseModule):
-    """Handles save options configuration for PhysiCell simulations."""
+    """Configure data output intervals and formats."""
     
     def __init__(self, config):
         super().__init__(config)
@@ -70,7 +68,21 @@ class SaveOptionsModule(BaseModule):
     def set_svg_plot_substrate(self, enabled: bool = False, limits: bool = False,
                               substrate: str = 'substrate', colormap: str = 'YlOrRd',
                               min_conc: float = 0, max_conc: float = 1) -> None:
-        """Set SVG substrate plotting options."""
+        """Configure plotting of a substrate concentration in SVG outputs.
+
+        Parameters
+        ----------
+        enabled:
+            Turn substrate plots on or off.
+        limits:
+            Whether min/max concentration limits are enforced.
+        substrate:
+            Name of the substrate to visualise.
+        colormap:
+            Matplotlib-style colormap name.
+        min_conc, max_conc:
+            Colour scale bounds.
+        """
         self.save_options['SVG']['plot_substrate'] = {
             'enabled': enabled,
             'limits': limits,
@@ -82,7 +94,7 @@ class SaveOptionsModule(BaseModule):
     
     def set_svg_legend(self, enabled: bool = False, cell_phase: bool = False,
                       cell_type: bool = True) -> None:
-        """Set SVG legend options."""
+        """Control the presence and contents of the SVG legend."""
         self.save_options['SVG']['legend'] = {
             'enabled': enabled,
             'cell_phase': cell_phase,
@@ -90,7 +102,7 @@ class SaveOptionsModule(BaseModule):
         }
     
     def set_legacy_data(self, enable: bool) -> None:
-        """Set legacy data save option."""
+        """Output additional legacy-format data files."""
         self.save_options['legacy_data']['enable'] = enable
     
     def add_to_xml(self, parent: ET.Element) -> None:

--- a/physicell_config/modules/substrates.py
+++ b/physicell_config/modules/substrates.py
@@ -1,6 +1,4 @@
-"""
-Substrate configuration module for PhysiCell.
-"""
+"""Definition of diffusive substrates present in the simulation."""
 
 from typing import Dict, Any, List, Optional, Tuple
 import xml.etree.ElementTree as ET
@@ -8,7 +6,7 @@ from .base import BaseModule
 
 
 class SubstrateModule(BaseModule):
-    """Handles substrate configuration for PhysiCell simulations."""
+    """Add substrates, boundary conditions and related options."""
     
     def __init__(self, config):
         super().__init__(config)
@@ -25,7 +23,23 @@ class SubstrateModule(BaseModule):
                      dirichlet_value: float = 0.0,
                      units: str = "dimensionless",
                      initial_units: str = "mmHg") -> None:
-        """Add a substrate to the configuration."""
+        """Create a new diffusive substrate entry.
+
+        Parameters
+        ----------
+        name:
+            Substrate identifier.
+        diffusion_coefficient:
+            Diffusion constant in :math:`\mu m^2/min`.
+        decay_rate:
+            First-order decay rate ``1/min``.
+        initial_condition:
+            Initial concentration value.
+        dirichlet_enabled, dirichlet_value:
+            Global Dirichlet condition settings.
+        units, initial_units:
+            Units for the concentration fields.
+        """
         self._validate_non_negative_number(diffusion_coefficient, "diffusion_coefficient")
         self._validate_non_negative_number(decay_rate, "decay_rate")
         
@@ -50,9 +64,9 @@ class SubstrateModule(BaseModule):
             }
         }
     
-    def set_dirichlet_boundary(self, substrate_name: str, boundary: str, 
+    def set_dirichlet_boundary(self, substrate_name: str, boundary: str,
                               enabled: bool, value: float = 0.0) -> None:
-        """Set Dirichlet boundary condition for a specific boundary."""
+        """Configure boundary-specific Dirichlet settings."""
         if substrate_name not in self.substrates:
             raise ValueError(f"Substrate '{substrate_name}' not found")
         


### PR DESCRIPTION
## Summary
- expand doc lists for every public function across modules
- highlight builtin cell_type_templates in advanced docs
- detail builtin template defaults

## Testing
- `python test_modular.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687807b840548331965cff86529674a4