### PR TITLE
Fix Dirichlet boundary boolean case in XML output

### DIFF
--- a/physicell_config/modules/substrates.py
+++ b/physicell_config/modules/substrates.py
@@ -128,14 +128,14 @@ class SubstrateModule(BaseModule):
             boundary_elem = self._create_element(variable_elem, "Dirichlet_boundary_condition", 
                                                substrate['dirichlet_value'])
             boundary_elem.set("units", substrate['initial_units'])
-            boundary_elem.set("enabled", "True" if substrate['dirichlet_enabled'] else "False")
+            boundary_elem.set("enabled", "true" if substrate['dirichlet_enabled'] else "false")
             
             # Dirichlet options (boundary-specific settings)
             dirichlet_opts_elem = self._create_element(variable_elem, "Dirichlet_options")
             for boundary_id, boundary_data in substrate['dirichlet_options'].items():
                 boundary_value_elem = ET.SubElement(dirichlet_opts_elem, "boundary_value")
                 boundary_value_elem.set("ID", boundary_id)
-                boundary_value_elem.set("enabled", "True" if boundary_data['enabled'] else "False")
+                boundary_value_elem.set("enabled", "true" if boundary_data['enabled'] else "false")
                 boundary_value_elem.text = str(boundary_data['value'])
         
         # Microenvironment options (always add these, even if no substrates)


### PR DESCRIPTION
## Summary

- Fix `substrates.py` generating `enabled="True"` / `enabled="False"` (Python capitalization) instead of lowercase `"true"` / `"false"` for Dirichlet boundary condition XML attributes
- PhysiCell's C++ XML parser expects lowercase booleans; the uppercase variant causes Dirichlet boundaries to be silently treated as disabled
- Affects both the global `Dirichlet_boundary_condition` element (line 131) and per-boundary `Dirichlet_options/boundary_value` elements (line 138)

## Context

All other modules in the package already use lowercase correctly (`cell_types.py`, `cell_rules.py`, `save_options.py`, `initial_conditions.py`). This appears to be an oversight limited to `substrates.py`.

**Before (broken):**
```xml
<Dirichlet_boundary_condition units="mmHg" enabled="True">38.0</Dirichlet_boundary_condition>
<boundary_value ID="xmin" enabled="True">38.0</boundary_value>
```

**After (fixed):**
```xml
<Dirichlet_boundary_condition units="mmHg" enabled="true">38.0</Dirichlet_boundary_condition>
<boundary_value ID="xmin" enabled="true">38.0</boundary_value>
```

## Test plan

- [x] Verified the bug exists in PyPI release v0.4.5
- [x] Confirmed PhysiCell rejects uppercase `"True"` (boundaries silently disabled)
- [x] Verified fix produces correct lowercase output
- [x] Confirmed all other modules already use lowercase (no regression risk)