### PR TITLE
Fix lossy load_xml: parse cell_interactions, cell_transformations, cell_integrity, initial_parameter_distributions

### DIFF
--- a/physicell_config/modules/cell_types.py
+++ b/physicell_config/modules/cell_types.py
@@ -1284,6 +1284,14 @@ class CellTypeModule(BaseModule):
             custom_data_elem = cell_def.find('custom_data')
             if custom_data_elem is not None:
                 self._parse_custom_data(name, custom_data_elem)
+
+            # Parse initial parameter distributions (sibling of phenotype)
+            distributions_elem = cell_def.find('initial_parameter_distributions')
+            if distributions_elem is not None:
+                self._parse_initial_parameter_distributions(
+                    self.cell_types[name]['initial_parameter_distributions'],
+                    distributions_elem,
+                )
     
     def _create_cell_type_structure(self, name: str, parent_type: Optional[str]) -> None:
         """Create the basic cell type data structure."""
@@ -1325,6 +1333,21 @@ class CellTypeModule(BaseModule):
         if secretion_elem is not None:
             self._parse_secretion(phenotype['secretion'], secretion_elem)
         
+        # Parse cell-cell interactions (phagocytosis, attack, fusion rates)
+        interactions_elem = phenotype_elem.find('cell_interactions')
+        if interactions_elem is not None:
+            self._parse_cell_interactions(phenotype['cell_interactions'], interactions_elem)
+
+        # Parse cell transformations (state-transition rates)
+        transformations_elem = phenotype_elem.find('cell_transformations')
+        if transformations_elem is not None:
+            self._parse_cell_transformations(phenotype['cell_transformations'], transformations_elem)
+
+        # Parse cell integrity (damage / repair rates)
+        integrity_elem = phenotype_elem.find('cell_integrity')
+        if integrity_elem is not None:
+            self._parse_cell_integrity(phenotype['cell_integrity'], integrity_elem)
+
         # Parse intracellular (PhysiBOSS)
         intracellular_elem = phenotype_elem.find('intracellular')
         if intracellular_elem is not None:
@@ -1477,7 +1500,131 @@ class CellTypeModule(BaseModule):
                 
                 if substrate_data:  # Only add if we have valid data
                     secretion_data[substrate_name] = substrate_data
-    
+
+    def _parse_cell_interactions(self, interactions_data: Dict[str, Any], interactions_elem: ET.Element) -> None:
+        """Parse cell-cell interaction parameters (phagocytosis, attack, fusion).
+
+        Reverses ``_add_cell_interactions_xml``. Fields not present in the XML
+        retain their template defaults in ``interactions_data``.
+        """
+        # Scalar phagocytosis / attack rates
+        scalar_fields = (
+            'apoptotic_phagocytosis_rate',
+            'necrotic_phagocytosis_rate',
+            'other_dead_phagocytosis_rate',
+            'attack_damage_rate',
+            'attack_duration',
+        )
+        for field in scalar_fields:
+            elem = interactions_elem.find(field)
+            if elem is not None and elem.text and elem.text.strip():
+                try:
+                    interactions_data[field] = float(elem.text.strip())
+                except ValueError:
+                    # Skip malformed values
+                    pass
+
+        # Dict-valued per-target rates
+        dict_fields = (
+            ('live_phagocytosis_rates', 'phagocytosis_rate'),
+            ('attack_rates', 'attack_rate'),
+            ('fusion_rates', 'fusion_rate'),
+        )
+        for container_tag, child_tag in dict_fields:
+            container = interactions_elem.find(container_tag)
+            if container is None:
+                continue
+            if container_tag not in interactions_data or not isinstance(
+                interactions_data[container_tag], dict
+            ):
+                interactions_data[container_tag] = {}
+            for rate_elem in container.findall(child_tag):
+                target_name = rate_elem.get('name')
+                if target_name and rate_elem.text and rate_elem.text.strip():
+                    try:
+                        interactions_data[container_tag][target_name] = float(
+                            rate_elem.text.strip()
+                        )
+                    except ValueError:
+                        pass
+
+    def _parse_cell_transformations(self, transformations_data: Dict[str, Any], transformations_elem: ET.Element) -> None:
+        """Parse cell transformation rates.
+
+        Reverses ``_add_cell_transformations_xml``.
+        """
+        rates_elem = transformations_elem.find('transformation_rates')
+        if rates_elem is None:
+            return
+        if 'transformation_rates' not in transformations_data or not isinstance(
+            transformations_data['transformation_rates'], dict
+        ):
+            transformations_data['transformation_rates'] = {}
+        for rate_elem in rates_elem.findall('transformation_rate'):
+            target_name = rate_elem.get('name')
+            if target_name and rate_elem.text and rate_elem.text.strip():
+                try:
+                    transformations_data['transformation_rates'][target_name] = float(
+                        rate_elem.text.strip()
+                    )
+                except ValueError:
+                    pass
+
+    def _parse_cell_integrity(self, integrity_data: Dict[str, Any], integrity_elem: ET.Element) -> None:
+        """Parse cell integrity (damage / repair) rates.
+
+        Reverses ``_add_cell_integrity_xml``.
+        """
+        for field in ('damage_rate', 'damage_repair_rate'):
+            elem = integrity_elem.find(field)
+            if elem is not None and elem.text and elem.text.strip():
+                try:
+                    integrity_data[field] = float(elem.text.strip())
+                except ValueError:
+                    pass
+
+    def _parse_initial_parameter_distributions(self, distributions_data: Dict[str, Any], distributions_elem: ET.Element) -> None:
+        """Parse initial parameter distributions.
+
+        Reverses ``_add_initial_parameter_distributions_xml``. Both Log10Normal
+        and LogUniform distribution types are recognised.
+        """
+        enabled_attr = distributions_elem.get('enabled')
+        if enabled_attr is not None:
+            distributions_data['enabled'] = enabled_attr.strip().lower() == 'true'
+
+        parsed = []
+        for dist_elem in distributions_elem.findall('distribution'):
+            dist: Dict[str, Any] = {
+                'enabled': (dist_elem.get('enabled') or 'false').strip().lower() == 'true',
+                'type': dist_elem.get('type', 'Log10Normal'),
+                'check_base': (dist_elem.get('check_base') or 'true').strip().lower() == 'true',
+            }
+
+            behavior_elem = dist_elem.find('behavior')
+            if behavior_elem is not None and behavior_elem.text and behavior_elem.text.strip():
+                dist['behavior'] = behavior_elem.text.strip()
+
+            if dist['type'] == 'Log10Normal':
+                numeric_keys = ('mu', 'sigma', 'upper_bound')
+            elif dist['type'] == 'LogUniform':
+                numeric_keys = ('min', 'max')
+            else:
+                numeric_keys = ()
+
+            for key in numeric_keys:
+                elem = dist_elem.find(key)
+                if elem is not None and elem.text and elem.text.strip():
+                    try:
+                        dist[key] = float(elem.text.strip())
+                    except ValueError:
+                        pass
+
+            parsed.append(dist)
+
+        if parsed:
+            distributions_data['distributions'] = parsed
+
     def _parse_custom_data(self, cell_name: str, custom_data_elem: ET.Element) -> None:
         """Parse custom data variables."""
         custom_data = self.cell_types[cell_name]['custom_data']

--- a/tests/test_cell_types_load_xml.py
+++ b/tests/test_cell_types_load_xml.py
@@ -1,0 +1,172 @@
+"""
+Regression tests for CellTypeModule.load_from_xml / _parse_phenotype.
+
+Earlier versions of the loader parsed cycle / death / volume / mechanics /
+motility / secretion / intracellular but silently dropped cell_interactions,
+cell_transformations, cell_integrity, and initial_parameter_distributions.
+A subsequent save_xml would then regenerate those sections from template
+defaults, masking any configuration the user had loaded.
+
+These tests exercise a round-trip (populate -> save_xml -> fresh load_xml)
+for each of those four sections and assert the reloaded data matches the
+pre-export state.
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+import pytest
+
+from physicell_config import PhysiCellConfig
+
+
+def _diff(before, after, path=""):
+    """Walk two nested structures; yield string descriptions of any mismatch."""
+    issues = []
+    if isinstance(before, dict):
+        for k, v in before.items():
+            if k not in after:
+                issues.append(f"{path}.{k} missing after reload")
+            else:
+                issues.extend(_diff(v, after[k], f"{path}.{k}"))
+    elif isinstance(before, list):
+        if not isinstance(after, list) or len(after) != len(before):
+            issues.append(
+                f"{path} length differs: {len(before)} -> "
+                f"{len(after) if isinstance(after, list) else type(after).__name__}"
+            )
+        else:
+            for i, (b, a) in enumerate(zip(before, after)):
+                issues.extend(_diff(b, a, f"{path}[{i}]"))
+    else:
+        if before != after:
+            issues.append(f"{path}: {before!r} -> {after!r}")
+    return issues
+
+
+@pytest.fixture
+def roundtrip_config(tmp_path: Path):
+    cfg = PhysiCellConfig()
+    cfg.cell_types.add_cell_type("tumor")
+    cfg.cell_types.add_cell_type("macrophage")
+
+    # cell_interactions: scalar + dict-valued fields
+    cfg.cell_types.set_attack_rate("macrophage", "tumor", 0.05)
+    cfg.cell_types.set_phagocytosis_rates(
+        "macrophage", apoptotic=0.01, necrotic=0.02, other_dead=0.005
+    )
+    mac_ci = cfg.cell_types.cell_types["macrophage"]["phenotype"]["cell_interactions"]
+    mac_ci["live_phagocytosis_rates"] = {"tumor": 0.03}
+    mac_ci["attack_damage_rate"] = 0.08
+    mac_ci["attack_duration"] = 15.0
+    cfg.cell_types.cell_types["tumor"]["phenotype"]["cell_interactions"][
+        "fusion_rates"
+    ] = {"tumor": 0.001}
+
+    # cell_transformations
+    cfg.cell_types.set_transformation_rate("tumor", "macrophage", 0.002)
+
+    # cell_integrity
+    integrity = cfg.cell_types.cell_types["tumor"]["phenotype"]["cell_integrity"]
+    integrity["damage_rate"] = 0.1
+    integrity["damage_repair_rate"] = 0.05
+
+    # initial_parameter_distributions (cell_def-level, not phenotype-level)
+    cfg.cell_types.cell_types["tumor"]["initial_parameter_distributions"] = {
+        "enabled": True,
+        "distributions": [
+            {
+                "enabled": True,
+                "type": "Log10Normal",
+                "check_base": True,
+                "behavior": "cycle entry",
+                "mu": -1.5,
+                "sigma": 0.3,
+                "upper_bound": 0.1,
+            },
+            {
+                "enabled": False,
+                "type": "LogUniform",
+                "check_base": False,
+                "behavior": "necrosis rate",
+                "min": 0.001,
+                "max": 0.01,
+            },
+        ],
+    }
+
+    xml_path = tmp_path / "roundtrip.xml"
+    cfg.save_xml(str(xml_path))
+
+    reloaded = PhysiCellConfig()
+    reloaded.load_xml(str(xml_path))
+
+    return cfg, reloaded
+
+
+def test_cell_interactions_roundtrip(roundtrip_config):
+    cfg, reloaded = roundtrip_config
+    for name in ("tumor", "macrophage"):
+        before = copy.deepcopy(
+            cfg.cell_types.cell_types[name]["phenotype"]["cell_interactions"]
+        )
+        after = reloaded.cell_types.cell_types[name]["phenotype"]["cell_interactions"]
+        assert not _diff(before, after), _diff(before, after)
+
+
+def test_cell_transformations_roundtrip(roundtrip_config):
+    cfg, reloaded = roundtrip_config
+    before = copy.deepcopy(
+        cfg.cell_types.cell_types["tumor"]["phenotype"]["cell_transformations"]
+    )
+    after = reloaded.cell_types.cell_types["tumor"]["phenotype"][
+        "cell_transformations"
+    ]
+    assert not _diff(before, after), _diff(before, after)
+    assert after["transformation_rates"]["macrophage"] == pytest.approx(0.002)
+
+
+def test_cell_integrity_roundtrip(roundtrip_config):
+    cfg, reloaded = roundtrip_config
+    before = copy.deepcopy(
+        cfg.cell_types.cell_types["tumor"]["phenotype"]["cell_integrity"]
+    )
+    after = reloaded.cell_types.cell_types["tumor"]["phenotype"]["cell_integrity"]
+    assert not _diff(before, after), _diff(before, after)
+
+
+def test_initial_parameter_distributions_roundtrip(roundtrip_config):
+    cfg, reloaded = roundtrip_config
+    before = copy.deepcopy(
+        cfg.cell_types.cell_types["tumor"]["initial_parameter_distributions"]
+    )
+    after = reloaded.cell_types.cell_types["tumor"]["initial_parameter_distributions"]
+    assert not _diff(before, after), _diff(before, after)
+    # Both distribution types survive with their type-specific keys intact
+    types = [d["type"] for d in after["distributions"]]
+    assert "Log10Normal" in types and "LogUniform" in types
+
+
+def test_missing_sections_leave_defaults_intact(tmp_path: Path):
+    """Cell defs without the four sections should not regress defaults."""
+    cfg = PhysiCellConfig()
+    cfg.cell_types.add_cell_type("plain")
+
+    xml_path = tmp_path / "plain.xml"
+    cfg.save_xml(str(xml_path))
+
+    reloaded = PhysiCellConfig()
+    reloaded.load_xml(str(xml_path))
+
+    assert "plain" in reloaded.cell_types.cell_types
+    phenotype = reloaded.cell_types.cell_types["plain"]["phenotype"]
+    # Sections still exist as dicts with defaults (not lost, not corrupted)
+    assert isinstance(phenotype["cell_interactions"], dict)
+    assert isinstance(phenotype["cell_transformations"], dict)
+    assert isinstance(phenotype["cell_integrity"], dict)
+    assert isinstance(
+        reloaded.cell_types.cell_types["plain"]["initial_parameter_distributions"],
+        dict,
+    )


### PR DESCRIPTION
## Summary

`CellTypeModule.load_from_xml` / `_parse_phenotype` silently drops four sections on round-trip (`load_xml` → `save_xml`): `cell_interactions`, `cell_transformations`, `cell_integrity`, and `initial_parameter_distributions`. The matching writers (`_add_cell_interactions_xml` etc.) emit those sections, but no parsers read them back, so any config loaded from XML regenerates those sections from template defaults on re-export.

This was surfaced during a downstream PhysiCell-recapitulation workflow where cell transformations in a hypoxia-migration model were being silently lost on re-export, wasting several iterations before the lossy round-trip was isolated.

## Changes

Adds four parser methods that reverse their writer counterparts:

- **`_parse_cell_interactions`** — scalar rates (apoptotic / necrotic / other_dead phagocytosis, `attack_damage_rate`, `attack_duration`) + dict-valued per-target rates (`live_phagocytosis_rates`, `attack_rates`, `fusion_rates`).
- **`_parse_cell_transformations`** — `transformation_rates` dict (target cell type → rate).
- **`_parse_cell_integrity`** — `damage_rate`, `damage_repair_rate`.
- **`_parse_initial_parameter_distributions`** — `enabled` flag + ordered `distributions` list, supporting both `Log10Normal` (mu / sigma / upper_bound) and `LogUniform` (min / max) variants with their `behavior`, `enabled`, `check_base` attributes.

Wiring:
- `_parse_phenotype` now calls the three phenotype-level parsers after secretion.
- `load_from_xml` calls `_parse_initial_parameter_distributions` alongside `_parse_custom_data` (it's a sibling of `<phenotype>`, not a child).

## Tests

Adds `tests/test_cell_types_load_xml.py` with five regression tests that exercise a populate → `save_xml` → fresh `load_xml` round-trip for each added parser, plus one test that a plain cell_def without these sections reloads cleanly without corrupting defaults.

## Test plan

- [x] Existing test suite passes: `pytest tests/` — 65 passed (on upstream `master` base 3b0d251).
- [x] New round-trip suite passes: `pytest tests/test_cell_types_load_xml.py` — 5 passed.
- [ ] Maintainer review for parser correctness against the writer schemas and for dict-structure alignment with the template defaults.

## Scope

No changes to writers, public API, or default values. This strictly adds parsers for existing writers so the load path matches the save path.
